### PR TITLE
chore: update url-service Docker setup and Traefik config

### DIFF
--- a/url-service/Dockerfile
+++ b/url-service/Dockerfile
@@ -1,5 +1,5 @@
 #Dependencies
-FROM node:20-alpine AS dependencies
+FROM node:22-alpine AS dependencies
 WORKDIR /app
 COPY package.json package-lock.json ./
 RUN npm install
@@ -12,13 +12,15 @@ RUN npx prisma generate
 RUN npm run build
 
 #Production
-FROM node:20-alpine AS production
+FROM node:22-alpine AS production
 WORKDIR /app
 COPY package.json package-lock.json ./
 RUN npm install --omit=dev
+
 COPY prisma/schema.prisma ./prisma/
 COPY --from=builder /app/dist ./dist
-COPY docker-entrypoint.sh .
-RUN chmod +x docker-entrypoint.sh
+
 EXPOSE 3000
-ENTRYPOINT ["/app/docker-entrypoint.sh"]
+RUN npx prisma generate
+
+CMD ["node", "dist/main.js"]

--- a/url-service/docker-compose.yml
+++ b/url-service/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.8'
-
 services:
   url-service:
     build:
@@ -14,17 +12,13 @@ services:
       - my-microservices-net
     labels:
       - "traefik.enable=true"
-      - "traefik.http.routers.url-service.rule=Host(`localhost`) && PathPrefix(`/urls`)"
+      - "traefik.http.routers.url-service.rule=Host(`localhost`) && PathPrefix(`/url`)"
       - "traefik.http.routers.url-service.entrypoints=web"
-      - "traefik.http.routers.url-service.middlewares=url-stripprefix"
-      - "traefik.http.middlewares.url-stripprefix.stripprefix.prefixes=/urls"
       - "traefik.http.services.url-service.loadbalancer.server.port=3000"
 
   mongodb:
     image: mongo:latest
     container_name: mongodb
-    ports:
-      - "27017:27017"
     networks:
       - my-microservices-net
     volumes:

--- a/url-service/docker-entrypoint.sh
+++ b/url-service/docker-entrypoint.sh
@@ -1,6 +1,0 @@
-#!/bin/sh
-echo "Running database migrations..."
-npx npx prisma generate
-
-echo "Starting the URL service..."
-exec node dist/main


### PR DESCRIPTION
Upgrade Node base images to 22-alpine for dependencies and production
stages to ensure up-to-date environment. Remove custom docker-entrypoint.sh
and replace it with direct CMD execution, running Prisma generate during
image build to simplify container startup. Adjust Traefik routing rule to
use /url prefix instead of /urls and remove unused middleware and port
mapping for MongoDB to streamline configuration.