### PR TITLE
chore: rename Docker network from my-microservices-net to url-shortener-net

### DIFF
--- a/gateway/docker-compose.yml
+++ b/gateway/docker-compose.yml
@@ -13,9 +13,9 @@ services:
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock:ro
     networks:
-      - my-microservices-net
+      - url-shortener-net
   
 networks:
-  my-microservices-net:
+  url-shortener-net:
     external: true
-    name: my-microservices-net
+    name: url-shortener-net

--- a/redirect-service/docker-compose.yml
+++ b/redirect-service/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       redis:
         condition: service_healthy
     networks:
-       - my-microservices-net
+       - url-shortener-net
     labels:
       - "traefik.enable=true"
       - "traefik.http.routers.redirect-service.rule=Host(`localhost`) && PathPrefix(`/r`)" 
@@ -23,7 +23,7 @@ services:
       redis:
         condition: service_healthy
     networks:
-       - my-microservices-net
+       - url-shortener-net
     labels:
       - "traefik.enable=true"
       - "traefik.http.routers.redirect-service.rule=Host(`localhost`) && PathPrefix(`/r`)" 
@@ -34,7 +34,7 @@ services:
   redis:
     image: "redis:alpine"
     networks:
-      - my-microservices-net
+      - url-shortener-net
     healthcheck:
       test: ["CMD", "redis-cli", "ping"]
       interval: 10s
@@ -43,5 +43,5 @@ services:
       start_period: 5s
 
 networks:
-  my-microservices-net: 
+  url-shortener-net: 
     external: true

--- a/url-service/docker-compose.yml
+++ b/url-service/docker-compose.yml
@@ -9,7 +9,7 @@ services:
       mongodb:
         condition: service_healthy
     networks:
-      - my-microservices-net
+      - url-shortener-net
     labels:
       - "traefik.enable=true"
       - "traefik.http.routers.url-service.rule=Host(`localhost`) && PathPrefix(`/url`)"
@@ -20,7 +20,7 @@ services:
     image: mongo:latest
     container_name: mongodb
     networks:
-      - my-microservices-net
+      - url-shortener-net
     volumes:
       - mongodb_data:/data/db
     command: ["--replSet", "rs0", "--bind_ip_all"]
@@ -38,7 +38,7 @@ services:
         condition: service_healthy
     restart: "no"
     networks:
-      - my-microservices-net
+      - url-shortener-net
     command: >
       mongosh --host mongodb:27017 --eval
       '
@@ -82,5 +82,5 @@ volumes:
   mongodb_data:
 
 networks:
-  my-microservices-net:
+  url-shortener-net:
     external: true

--- a/user-service/docker-compose.yml
+++ b/user-service/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       postgres:
         condition: service_healthy
     networks:
-      - my-microservices-net
+      - url-shortener-net
     labels:
       - "traefik.enable=true"
       - "traefik.http.routers.users-service.rule=Host(`localhost`) && PathPrefix(`/users`)"
@@ -21,7 +21,7 @@ services:
     image: postgres:17-alpine
     restart: always
     networks:
-      - my-microservices-net
+      - url-shortener-net
     environment:
       POSTGRES_DB: users
       POSTGRES_USER: postgres
@@ -39,5 +39,5 @@ volumes:
   postgres-data:
 
 networks:
-  my-microservices-net:
+  url-shortener-net:
     external: true


### PR DESCRIPTION
Update all docker-compose.yml files to use the external network
url-shortener-net instead of my-microservices-net. This change aligns
the network naming with the project context and ensures consistent
network configuration across redirect-service, gateway, url-service,
and user-service.