### PR TITLE
build: add Makefile targets for building and cleaning services

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,41 @@
+.PHONY: all clean api-gateway redirect-service url-service user-service frontend
+
+api-gateway:
+	@echo "Building api-gateway..."
+	@cd api-gateway &&\
+	make up &&\
+	cd ..
+
+redirect-service:
+	@echo "Building redirect-service..."
+	@cd redirect-service &&\
+	make up &&\
+	cd ..
+
+url-service:
+	@echo "Building url-service..."
+	@cd url-service &&\
+	make up &&\
+	cd ..
+
+user-service:
+	@echo "Building user-service..."
+	@cd user-service &&\
+	make up &&\
+	cd ..
+
+frontend:
+	@echo "Building frontend..."
+	@cd frontend &&\
+	make up &&\
+	cd ..
+
+all: api-gateway redirect-service url-service user-service frontend
+
+clean:
+	@echo "Cleaning up all services..."
+	@cd api-gateway && make down && cd ..
+	@cd redirect-service && make down && cd ..
+	@cd url-service && make down && cd ..
+	@cd user-service && make down && cd ..
+	@cd frontend && make down && cd ..


### PR DESCRIPTION
Add individual Makefile targets for api-gateway, redirect-service,
url-service, user-service, and frontend to streamline building each
component. Introduce an all target to build all services in sequence.

Implement a clean target to stop and clean all services, improving
project maintenance and simplifying common workflows.