### PR TITLE
feat(security): add CORS support and update security config

### DIFF
--- a/user-service/docker-compose.yml
+++ b/user-service/docker-compose.yml
@@ -14,9 +14,10 @@ services:
       - "traefik.enable=true"
       - "traefik.http.routers.users-service.rule=Host(`localhost`) && PathPrefix(`/users`)"
       - "traefik.http.routers.users-service.entrypoints=web"
+      - "traefik.http.middlewares.users-prefix.headers.customrequestheaders.X-Forwarded-Prefix=/users"
       - "traefik.http.routers.users-service.middlewares=users-stripprefix"
       - "traefik.http.middlewares.users-stripprefix.stripprefix.prefixes=/users"
-      - "traefik.http.services.users-service.loadbalancer.server.port=8083"
+      - "traefik.http.services.users-service.loadbalancer.server.port=8080"
     restart: always
 
   postgres:

--- a/user-service/src/main/java/ltphat/UserService/config/SecurityConfig.java
+++ b/user-service/src/main/java/ltphat/UserService/config/SecurityConfig.java
@@ -3,9 +3,11 @@ package ltphat.UserService.config;
 import ltphat.UserService.security.CustomOAuth2UserService;
 import ltphat.UserService.security.JwtFilter;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
@@ -15,6 +17,11 @@ import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+
+import java.util.List;
 
 @Configuration
 @EnableWebSecurity
@@ -25,6 +32,9 @@ public class SecurityConfig {
 
     @Autowired
     private CustomOAuth2UserService customOAuth2UserService;
+
+    @Value("${FRONTEND_URL}")
+    private String frontendUrl;
 
     @Bean
     public PasswordEncoder passwordEncoder() {
@@ -37,29 +47,45 @@ public class SecurityConfig {
     }
 
     @Bean
+    public CorsConfigurationSource corsConfigurationSource() {
+        CorsConfiguration configuration = new CorsConfiguration();
+
+        configuration.setAllowedOrigins(List.of(frontendUrl));
+        configuration.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "OPTIONS"));
+        configuration.setAllowedHeaders(List.of("*"));
+        configuration.setAllowCredentials(true);
+
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", configuration);
+        return source;
+    }
+
+    @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
         http
-                .csrf(AbstractHttpConfigurer::disable) // Vô hiệu hóa CSRF
+                .csrf(AbstractHttpConfigurer::disable)
+                .cors(Customizer.withDefaults())
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers(
-                                "/login",
-                                "/register",
-                                "/oauth2/**",
-                                "/token/validate",
-                                "/actuator/health"
-                        ).permitAll() // Các endpoint công khai
-                        .anyRequest().authenticated() // Tất cả các request khác cần xác thực
+                                "/users/login",
+                                "/users/register",
+                                "/users/oauth2/**",
+                                "/users/login/oauth2/code/**",
+                                "/users/token/validate",
+                                "/users/actuator/health"
+                        ).permitAll()
+                        .anyRequest().authenticated()
                 )
                 .sessionManagement(session -> session
-                        .sessionCreationPolicy(SessionCreationPolicy.STATELESS) // Không sử dụng session
+                        .sessionCreationPolicy(SessionCreationPolicy.STATELESS)
                 )
                 .oauth2Login(oauth2 -> oauth2
                         .userInfoEndpoint(userInfo -> userInfo
                                 .userService(customOAuth2UserService)
                         )
-                        .defaultSuccessUrl("http://localhost:3000") // Chuyển hướng sau khi login OAuth2 thành công
+                        .defaultSuccessUrl(frontendUrl)
                 )
-                .addFilterBefore(jwtFilter, UsernamePasswordAuthenticationFilter.class); // Thêm filter JWT
+                .addFilterBefore(jwtFilter, UsernamePasswordAuthenticationFilter.class);
 
         return http.build();
     }

--- a/user-service/src/main/resources/application.yml
+++ b/user-service/src/main/resources/application.yml
@@ -1,11 +1,12 @@
 server:
   port: ${SERVER_PORT:8080}
+  forward-headers-strategy: framework
 
 spring:
   application:
     name: user-service
   datasource:
-    url: jdbc:postgresql://localhost:5432/users
+    url: jdbc:postgresql://${DB_HOST:localhost}:5432/users
     username: ${DB_USERNAME:postgres}
     password: ${DB_PASSWORD:12345}
   jpa:


### PR DESCRIPTION
Configure CORS to allow requests from the frontend URL with proper
methods and headers, enabling cross-origin requests securely. Update
security filter chain to enable CORS and refine public endpoint paths
to include /users prefix. Set OAuth2 login success redirect to the
frontend URL from configuration. Add Traefik middleware header to
handle forwarded prefix for /users path. These changes improve
frontend-backend integration and security handling.