### PR TITLE
fix: remove credentials from fetch options and healthcheck from compose

### DIFF
--- a/front-end/src/services/urlService.js
+++ b/front-end/src/services/urlService.js
@@ -4,7 +4,6 @@ const SHORT_URL_BASE = 'http://localhost/r/'
 // Cấu hình chung cho fetch requests để xử lý CORS
 const DEFAULT_FETCH_OPTIONS = {
 	mode: 'cors',
-	credentials: 'include',
 	headers: {
 		'Content-Type': 'application/json',
 		'Accept': 'application/json',

--- a/front-end/src/services/userService.js
+++ b/front-end/src/services/userService.js
@@ -3,7 +3,6 @@ const API_BASE_URL = import.meta.env.VITE_API_GATEWAY_BASE_URL || 'http://localh
 // Cấu hình chung cho fetch requests để xử lý CORS
 const DEFAULT_FETCH_OPTIONS = {
 	mode: 'cors',
-	credentials: 'include',
 	headers: {
 		'Content-Type': 'application/json',
 		'Accept': 'application/json',

--- a/url-service/docker-compose.yml
+++ b/url-service/docker-compose.yml
@@ -16,12 +16,6 @@ services:
       - "traefik.http.routers.url-service.entrypoints=web"
       - "traefik.http.services.url-service.loadbalancer.server.port=3000"
     restart: unless-stopped
-    healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:3000/health"]
-      interval: 30s
-      timeout: 10s
-      retries: 5
-      start_period: 30s
 
   mongodb:
     image: mongo:latest


### PR DESCRIPTION
- Remove 'credentials: include' from fetch requests in urlService and userService to avoid sending cookies with CORS requests, improving security and preventing potential issues with cross-origin calls.
- Delete the healthcheck configuration from url-service in docker-compose to simplify container setup and avoid unnecessary health check failures.