### PR TITLE
fix: add middleware annotation and correct env vars indentation

### DIFF
--- a/k8s/redirect-service/deployment.yaml
+++ b/k8s/redirect-service/deployment.yaml
@@ -14,13 +14,13 @@ spec:
         app: redirect-service
     spec:
       containers:
-      - name: redirect-service
-        image: redirect-service:latest
-        imagePullPolicy: IfNotPresent
-        ports:
-        - containerPort: 8080
-        env:
-        - name: REDIS_ADDR
-          value: "redis-service:6379"
-        - name: URL_SERVICE_BASE_URL
-          value: "http://url-service"
+        - name: redirect-service
+          image: redirect-service:latest
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 8080
+          env:
+            - name: REDIS_ADDR
+              value: "redis:6379"
+            - name: URL_SERVICE_BASE_URL
+              value: "http://url-service"

--- a/k8s/user-service/ingress.yaml
+++ b/k8s/user-service/ingress.yaml
@@ -3,16 +3,18 @@ kind: Ingress
 metadata:
   name: user-service-ingress
   namespace: url-shortener
+  annotations:
+    traefik.ingress.kubernetes.io/router.middlewares: url-shortener-user-stripprefix@kubernetescrd
 spec:
   ingressClassName: traefik
   rules:
-  - host: localhost
-    http:
-      paths:
-      - path: /users
-        pathType: Prefix
-        backend:
-          service:
-            name: user-service
-            port:
-              name: http
+    - host: localhost
+      http:
+        paths:
+          - path: /users
+            pathType: Prefix
+            backend:
+              service:
+                name: user-service
+                port:
+                  name: http


### PR DESCRIPTION
Add Traefik middleware annotation to user-service ingress to enable
request path prefix stripping. Fix indentation and update Redis address
environment variable in redirect-service deployment for consistency and
correctness.