### PR TITLE
v-branch-1

### DIFF
--- a/k8s/redirect-service/ingress.yaml
+++ b/k8s/redirect-service/ingress.yaml
@@ -1,20 +1,17 @@
-apiVersion: networking.k8s.io/v1
-kind: Ingress
+apiVersion: traefik.io/v1alpha1
+kind: IngressRoute
 metadata:
   name: redirect-service-ingress
   namespace: url-shortener
-  annotations:
-    traefik.ingress.kubernetes.io/router.middlewares: url-shortener-redirect-stripprefix@kubernetescrd
 spec:
-  ingressClassName: traefik
-  rules:
-  - host: localhost
-    http:
-      paths:
-      - path: /r
-        pathType: Prefix
-        backend:
-          service:
-            name: redirect-service
-            port:
-              name: http
+  entryPoints: 
+  - web
+  routes:
+  - match: Host(`localhost`) && PathPrefix(`/r`)
+    kind: Rule
+    middlewares: 
+    - name: redirect-stripprefix
+    services:
+    - name: redirect-service
+      port: http
+  

--- a/k8s/url-service/ingress.yaml
+++ b/k8s/url-service/ingress.yaml
@@ -1,18 +1,14 @@
-apiVersion: networking.k8s.io/v1
-kind: Ingress
+apiVersion: traefik.io/v1alpha1
+kind: IngressRoute
 metadata:
   name: url-service-ingress
   namespace: url-shortener
 spec:
-  ingressClassName: traefik
-  rules:
-  - host: localhost
-    http:
-      paths:
-      - path: /url
-        pathType: Prefix
-        backend:
-          service:
-            name: url-service
-            port:
-              name: http
+  entryPoints:
+  - web
+  routes:
+  - match: Host(`localhost`) && PathPrefix(`/url`)
+    kind: Rule
+    services:
+    - name: url-service
+      port: http

--- a/k8s/user-service/ingress.yaml
+++ b/k8s/user-service/ingress.yaml
@@ -1,20 +1,17 @@
-apiVersion: networking.k8s.io/v1
-kind: Ingress
+apiVersion: traefik.io/v1alpha1
+kind: IngressRoute
 metadata:
   name: user-service-ingress
   namespace: url-shortener
-  annotations:
-    traefik.ingress.kubernetes.io/router.middlewares: url-shortener-user-stripprefix@kubernetescrd
 spec:
-  ingressClassName: traefik
-  rules:
-    - host: localhost
-      http:
-        paths:
-          - path: /users
-            pathType: Prefix
-            backend:
-              service:
-                name: user-service
-                port:
-                  name: http
+  entryPoints:
+  - web
+  routes:
+  - match: Host(`localhost`) && PathPrefix(`/users`)
+    kind: Rule
+    middlewares: 
+      - name: user-stripprefix
+    services:
+      - name: user-service
+        port: http
+  


### PR DESCRIPTION
- Migrated Ingress manifests for url-service, user-service, and redirect-service to use Traefik IngressRoute CRD instead of standard Kubernetes Ingress.
- Updated routing to leverage Traefik's native CRD support for enhanced flexibility and middleware configuration.
- Explicitly referenced middlewares for path prefix stripping in routes for better clarity and maintainability.
- Set entry points to "web" to align with Traefik's expected setup.