### PR TITLE
docs: add steps to build/start services in Minikube

### DIFF
--- a/docs/setup.md
+++ b/docs/setup.md
@@ -90,6 +90,28 @@ make k8s-deploy-all
 ```sh
 minikube tunnel
 ```
-### 1.6. Access the Application
 
+### 2.5. Build and Start a specific service
+- run 
+```sh
+minikube start --driver=docker
+minikube -p minikube docker-env | Invoke-Expression
+```
+**Note:**  
+These commands will start Minikube and configure your terminal so that all `docker build` commands will build images directly into Minikube’s Docker environment.  
+
+**You must run these commands in every new terminal session before building images or deploying with the Makefile.**  
+
+If you skip this step, Kubernetes will not be able to find your locally built images.
+
+- run
+```sh
+make k8s-deploy-<service_name>
+```
+Replace `<service_name>` with one of: `api-gateway`, `redirect-service`, `url-service`, `user-service`, `frontend`, `cache`.
+**Note:**  
+**You must deploy traefik first if you want to use back-end service (all service except front-end)**
+
+### 2.6. Access the Application
+- Dashboard: [http://localhost/dashboard/](http://localhost/dashboard/)
 - Frontend: [http://localhost:3030](http://localhost:3030)


### PR DESCRIPTION
Add a new "Build and Start a specific service" section to the setup docs that explains how to start Minikube with the Docker driver and how to configure the shell so docker builds go directly into Minikube's Docker environment. Document the requirement to run these commands in every new terminal session to ensure Kubernetes can find locally built images. Provide the make target to deploy an individual service and list available service names, and note that Traefik must be deployed first for back-end services. Move and rename the "Access the Application" heading to reflect the new ordering.

This clarifies the local development flow and fixes issues where Kubernetes could not locate locally built images when users forgot to configure the Docker environment.